### PR TITLE
Add workflows for GitHub Pages preview, deployment, and cleanup

### DIFF
--- a/.github/workflows/cleanup-pages-previews.yml
+++ b/.github/workflows/cleanup-pages-previews.yml
@@ -1,0 +1,44 @@
+name: Cleanup Pages Previews
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove stale preview deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d '5 days ago' +%s)
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            repos/$REPOSITORY/pages/deployments \
+            --paginate \
+            | jq -r --argjson cutoff "$cutoff" '
+                (if type == "array" then .[] else . end)
+                | select(.preview == true)
+                | select((.created_at | fromdateiso8601) < $cutoff)
+                | .id
+              ' \
+            | sort -u \
+            | while read -r deployment_id; do
+                if [ -n "$deployment_id" ]; then
+                  echo "Deleting deployment $deployment_id"
+                  gh api \
+                    -X DELETE \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    repos/$REPOSITORY/pages/deployments/$deployment_id
+                fi
+              done

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,47 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: production-pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: _site
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/preview-pages.yml
+++ b/.github/workflows/preview-pages.yml
@@ -1,0 +1,93 @@
+name: Preview Pages Deployment
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: _site
+
+      - name: Deploy preview
+        id: deployment
+        uses: actions/deploy-pages@v3
+        with:
+          preview: true
+
+      - name: Comment preview URL
+        if: ${{ steps.deployment.outputs.page_url }}
+        uses: actions/github-script@v7
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        with:
+          script: |
+            const core = require('@actions/core');
+            const marker = '<!-- preview-comment -->';
+            const url = process.env.PAGE_URL;
+            if (!url) {
+              core.setFailed('Preview URL output was empty.');
+              return;
+            }
+
+            const body = `${marker}\n🚀 GitHub Pages preview available at: ${url}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }


### PR DESCRIPTION
## Summary
- add a preview workflow that builds the Jekyll site, deploys a GitHub Pages preview, and comments the URL on pull requests
- configure a production workflow to publish the site whenever the main branch updates
- schedule a nightly cleanup job to delete preview deployments older than five days using the GitHub CLI and jq

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d0dc8aabf08333a327eff3542eb00f