### PR TITLE
Enable PR preview deployments for GitHub Pages

### DIFF
--- a/.github/workflows/jekyll-pr-preview.yml
+++ b/.github/workflows/jekyll-pr-preview.yml
@@ -52,3 +52,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          preview: true


### PR DESCRIPTION
## Summary
- ensure the PR workflow deploys to the GitHub Pages preview environment instead of production

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d15666abc88333aa94612a959f68d6