### PR TITLE
Adopt Plus Jakarta Sans for consistent site typography

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,15 +6,26 @@
   --accent-color: #007aff;
   --border-color: #e5e5e5;
   --header-height: 80px;
+  --font-primary: 'Plus Jakarta Sans', 'Nunito Sans', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+  --font-code: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+body,
+button,
+input,
+select,
+textarea {
+  font-family: var(--font-primary);
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  line-height: 1.6;
+  font-weight: 400;
+  line-height: 1.7;
   color: var(--text-primary);
   background-color: var(--background-primary);
   margin: 0;
   padding: 0;
+  letter-spacing: 0.01em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -50,9 +61,18 @@ h3 { font-size: 1.5rem; }
 h4, h5, h6 { font-size: 1.25rem; }
 
 h1, h2, h3, h4, h5, h6 {
+  font-family: inherit;
   font-weight: 600;
+  letter-spacing: -0.01em;
   margin-top: 2em;
   margin-bottom: 0.5em;
+}
+
+code,
+pre,
+samp,
+kbd {
+  font-family: var(--font-code);
 }
 
 /* Header */


### PR DESCRIPTION
## Summary
- replace the Inter font import with Plus Jakarta Sans for a softer, calming default typeface
- unify typography across body copy, form controls, headings, and code snippets using reusable CSS variables and spacing tweaks

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d15755344c8333ac7ace2991a06951