### PR TITLE
Adjust homepage layout responsiveness

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
-<body class="{% if page.layout == 'post' %}post-page {% endif %}{% if page.url == '/blogs/' or page.permalink == '/blogs/' %}blogs-page{% endif %}">
+<body class="{% if page.layout == 'post' %}post-page {% endif %}{% if page.url == '/' or page.permalink == '/' %}home-page {% endif %}{% if page.url == '/blogs/' or page.permalink == '/blogs/' %}blogs-page{% endif %}">
   <div class="container">
     <header>
       <nav>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -450,6 +450,15 @@ footer a {
   margin-bottom: 15px;
 }
 
+/* Home layout */
+.home-container {
+  width: 100%;
+  max-width: 60vw;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  box-sizing: border-box;
+}
+
 /* Blog styles */
 .blog-container {
   width: 100%;
@@ -571,6 +580,11 @@ footer a {
     text-align: left;
   }
 
+  .home-container {
+    max-width: 100%;
+    padding: 0 1.25rem;
+  }
+
   .blog-container {
     width: 100%;
     max-width: 100%;
@@ -583,7 +597,8 @@ footer a {
 }
 
 body.post-page .container > main,
-body.blogs-page .container > main {
+body.blogs-page .container > main,
+body.home-page .container > main {
   width: 100%;
   padding-left: 0;
   padding-right: 0;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 title: "Home"
 ---
 
-<div class="container">
+<div class="home-container">
   <div class="intro-section">
     <div class="intro-text">
       <h1>Zafarullah Mahmood</h1>


### PR DESCRIPTION
## Summary
- tag the home view with a dedicated `home-page` body class so its layout can be targeted separately from posts and blogs
- wrap the homepage content in a new `.home-container` and style it to use 60% viewport width on large screens while expanding to full width on small devices

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d1578960848333bd9e70ae8dd416c8