### PR TITLE
Constrain header navigation to sixty percent width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -28,7 +28,13 @@ body {
   box-sizing: border-box;
 }
 
-.container > header,
+.container > header {
+  width: 60vw;
+  margin: 0 auto;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
 .container > main,
 .container > footer {
   width: min(90vw, 1200px);
@@ -71,9 +77,8 @@ header nav {
   justify-content: space-between;
   align-items: center;
   height: 100%;
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0 20px;
+  width: 100%;
+  padding: 0;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- set the header container to occupy sixty percent of the viewport so the navigation and underline stay centered and consistent
- ensure the navigation bar fills the new header width by letting the flex container span the full header

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d15e41f65c83339a470d6460596e50