### PR TITLE
Link skills badges to official sites

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -353,6 +353,7 @@ footer a {
   border: 1px solid var(--badge-border);
   box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
   color: var(--badge-text);
+  text-decoration: none;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 

--- a/index.html
+++ b/index.html
@@ -111,20 +111,19 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">{ }</span>
           <h3>Programming Languages</h3>
         </div>
-        <p>I prototype in Python, keep my C/C++ fundamentals sharp, and draw on past JavaScript experience when extending UI workflows.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-python">
+          <a class="skill-badge skill-python" href="https://www.python.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/python.svg" alt="Python logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Python</span>
-          </span>
-          <span class="skill-badge skill-cpp">
+          </a>
+          <a class="skill-badge skill-cpp" href="https://isocpp.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/cpp.svg" alt="C and C plus plus logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">C/C++</span>
-          </span>
-          <span class="skill-badge skill-javascript">
+          </a>
+          <a class="skill-badge skill-javascript" href="https://developer.mozilla.org/docs/Web/JavaScript" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/javascript.svg" alt="JavaScript logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">JavaScript</span>
-          </span>
+          </a>
         </div>
       </div>
       <div class="skills-card">
@@ -132,24 +131,23 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">&#129302;</span>
           <h3>Deep Learning &amp; NLP</h3>
         </div>
-        <p>I combine production pragmatism with research fluency using modern deep learning frameworks and NLP libraries.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-pytorch">
+          <a class="skill-badge skill-pytorch" href="https://pytorch.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/pytorch.svg" alt="PyTorch logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">PyTorch</span>
-          </span>
-          <span class="skill-badge skill-nemo">
+          </a>
+          <a class="skill-badge skill-nemo" href="https://developer.nvidia.com/nemo-framework" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/nemo.svg" alt="NVIDIA NeMo logo" loading="lazy" width="36" height="32" />
             <span class="skill-name">NVIDIA NeMo</span>
-          </span>
-          <span class="skill-badge skill-huggingface">
+          </a>
+          <a class="skill-badge skill-huggingface" href="https://huggingface.co/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/huggingface.png" alt="Hugging Face logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">HuggingFace</span>
-          </span>
-          <span class="skill-badge skill-spacy">
+          </a>
+          <a class="skill-badge skill-spacy" href="https://spacy.io/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/spacy.svg" alt="spaCy logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">spaCy</span>
-          </span>
+          </a>
         </div>
       </div>
       <div class="skills-card">
@@ -157,28 +155,27 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">&#9889;</span>
           <h3>Generative AI Systems</h3>
         </div>
-        <p>I orchestrate multi-agent and retrieval-augmented flows with modern tooling, and evaluate them with rigor.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-langchain">
+          <a class="skill-badge skill-langchain" href="https://www.langchain.com/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/langchain.svg" alt="LangChain logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">LangChain</span>
-          </span>
-          <span class="skill-badge skill-langgraph">
+          </a>
+          <a class="skill-badge skill-langgraph" href="https://www.langchain.com/langgraph" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/langgraph.svg" alt="LangGraph logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">LangGraph</span>
-          </span>
-          <span class="skill-badge skill-llamaindex">
+          </a>
+          <a class="skill-badge skill-llamaindex" href="https://www.llamaindex.ai/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/llamaindex.svg" alt="LlamaIndex logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">LlamaIndex</span>
-          </span>
-          <span class="skill-badge skill-ragas">
+          </a>
+          <a class="skill-badge skill-ragas" href="https://github.com/explodinggradients/ragas" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/ragas.png" alt="RAGAs logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">RAGAs</span>
-          </span>
-          <span class="skill-badge skill-vllm">
+          </a>
+          <a class="skill-badge skill-vllm" href="https://vllm.ai/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/vllm.png" alt="vLLM logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">vLLM</span>
-          </span>
+          </a>
         </div>
       </div>
       <div class="skills-card">
@@ -186,36 +183,35 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">&#128736;</span>
           <h3>MLOps &amp; Cloud</h3>
         </div>
-        <p>From containerization to managed services, I design pipelines that stay observable and cost-aware in production.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-docker">
+          <a class="skill-badge skill-docker" href="https://www.docker.com/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/docker.svg" alt="Docker logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Docker</span>
-          </span>
-          <span class="skill-badge skill-kubernetes">
+          </a>
+          <a class="skill-badge skill-kubernetes" href="https://kubernetes.io/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/kubernetes.svg" alt="Kubernetes logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Kubernetes</span>
-          </span>
-          <span class="skill-badge skill-ecs">
+          </a>
+          <a class="skill-badge skill-ecs" href="https://aws.amazon.com/ecs/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/ecs.png" alt="Amazon Elastic Container Service logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Elastic CS</span>
-          </span>
-          <span class="skill-badge skill-kubeflow">
+          </a>
+          <a class="skill-badge skill-kubeflow" href="https://www.kubeflow.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/kubeflow.svg" alt="Kubeflow logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Kubeflow</span>
-          </span>
-          <span class="skill-badge skill-bedrock">
+          </a>
+          <a class="skill-badge skill-bedrock" href="https://aws.amazon.com/bedrock/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/bedrock.png" alt="AWS Bedrock logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">AWS Bedrock</span>
-          </span>
-          <span class="skill-badge skill-sagemaker">
+          </a>
+          <a class="skill-badge skill-sagemaker" href="https://aws.amazon.com/sagemaker/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/sagemaker.png" alt="Amazon SageMaker logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">SageMaker</span>
-          </span>
-          <span class="skill-badge skill-vertex">
+          </a>
+          <a class="skill-badge skill-vertex" href="https://cloud.google.com/vertex-ai" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/vertex.svg" alt="Google Cloud Vertex AI logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">GCP Vertex AI</span>
-          </span>
+          </a>
         </div>
       </div>
       <div class="skills-card">
@@ -223,32 +219,31 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">&#128202;</span>
           <h3>Data &amp; Vector Stores</h3>
         </div>
-        <p>I architect storage and retrieval layers that keep AI applications responsive to ever-growing knowledge bases.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-bigquery">
+          <a class="skill-badge skill-bigquery" href="https://cloud.google.com/bigquery" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/bigquery.png" alt="BigQuery logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">BigQuery</span>
-          </span>
-          <span class="skill-badge skill-postgres">
+          </a>
+          <a class="skill-badge skill-postgres" href="https://www.postgresql.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/postgres.svg" alt="PostgreSQL logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">PostgreSQL</span>
-          </span>
-          <span class="skill-badge skill-firestore">
+          </a>
+          <a class="skill-badge skill-firestore" href="https://firebase.google.com/docs/firestore" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/firestore.png" alt="Firestore logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Firestore</span>
-          </span>
-          <span class="skill-badge skill-redis">
+          </a>
+          <a class="skill-badge skill-redis" href="https://redis.io/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/redis.svg" alt="Redis logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Redis</span>
-          </span>
-          <span class="skill-badge skill-chromadb">
+          </a>
+          <a class="skill-badge skill-chromadb" href="https://www.trychroma.com/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/chromadb.svg" alt="ChromaDB logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">ChromaDB</span>
-          </span>
-          <span class="skill-badge skill-faiss">
+          </a>
+          <a class="skill-badge skill-faiss" href="https://faiss.ai/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/faiss.svg" alt="FAISS logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">FAISS</span>
-          </span>
+          </a>
         </div>
       </div>
       <div class="skills-card">
@@ -256,28 +251,27 @@ title: "Home"
           <span class="card-icon" aria-hidden="true">&#128187;</span>
           <h3>Product Engineering</h3>
         </div>
-        <p>I round out ML solutions with pragmatic web and service layers that make models usable by real teams.</p>
         <div class="skill-badges">
-          <span class="skill-badge skill-flask">
+          <a class="skill-badge skill-flask" href="https://flask.palletsprojects.com/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/flask.svg" alt="Flask logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Flask</span>
-          </span>
-          <span class="skill-badge skill-sanic">
+          </a>
+          <a class="skill-badge skill-sanic" href="https://sanic.dev/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/sanic.svg" alt="Sanic logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Sanic</span>
-          </span>
-          <span class="skill-badge skill-sqlalchemy">
+          </a>
+          <a class="skill-badge skill-sqlalchemy" href="https://www.sqlalchemy.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/sqlalchemy.svg" alt="SQLAlchemy logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">SQLAlchemy</span>
-          </span>
-          <span class="skill-badge skill-alembic">
+          </a>
+          <a class="skill-badge skill-alembic" href="https://alembic.sqlalchemy.org/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/alembic.svg" alt="Alembic logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Alembic</span>
-          </span>
-          <span class="skill-badge skill-angular">
+          </a>
+          <a class="skill-badge skill-angular" href="https://angular.io/" target="_blank" rel="noopener noreferrer">
             <img src="assets/img/skills/angular.svg" alt="Angular logo" loading="lazy" width="32" height="32" />
             <span class="skill-name">Angular</span>
-          </span>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- turn each skills badge into an external link to the corresponding technology site for quicker exploration
- drop redundant descriptive paragraphs from the skill cards for a cleaner layout
- ensure badge styling works for anchors by removing default link decoration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17f1673048333aabbb9aa6ccd3a6d