### PR TITLE
Restyle homepage typography and palettes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400&family=Work+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="icon" type="image/svg+xml" href="{{ "/assets/favicon.svg" | relative_url }}">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/favicon-32.png" | relative_url }}">
   <link rel="icon" type="image/png" sizes="192x192" href="{{ "/assets/favicon-512.png" | relative_url }}">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,24 +1,45 @@
+/* Typography & palette inspired by thekev.in */
+
 /* General styles */
 :root {
-  --text-primary: #333;
-  --text-secondary: #555;
-  --background-primary: #fff;
-  --accent-color: #007aff;
-  --border-color: #e5e5e5;
+  --text-primary: #3a3227;
+  --text-secondary: #6b6152;
+  --text-muted: #9a907f;
+  --background-primary: #f6f1e7;
+  --surface-card: rgba(255, 255, 252, 0.94);
+  --surface-elevated: #ffffff;
+  --accent-color: #c66b3d;
+  --border-color: rgba(133, 117, 96, 0.25);
+  --soft-shadow: 0 18px 40px rgba(73, 56, 36, 0.12);
   --header-height: 80px;
-  --font-family-base: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-family-heading: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-family-base: 'Source Serif 4', 'Georgia', 'Times New Roman', serif;
+  --font-family-heading: 'Work Sans', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+}
+
+html {
+  font-size: 15.4px;
 }
 
 body {
   font-family: var(--font-family-base);
-  line-height: 1.6;
+  line-height: 1.7;
   color: var(--text-primary);
-  background-color: var(--background-primary);
+  background: linear-gradient(180deg, rgba(246, 241, 231, 0.96), rgba(243, 235, 220, 0.88));
   margin: 0;
   padding: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+p,
+li {
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+}
+
+p {
+  margin: 0.9rem 0;
+  max-width: 75ch;
 }
 
 .container {
@@ -28,18 +49,12 @@ body {
   box-sizing: border-box;
 }
 
-.container > header {
-  width: 60vw;
-  margin: 0 auto;
-  padding: 0 20px;
-  box-sizing: border-box;
-}
-
+.container > header,
 .container > main,
 .container > footer {
-  width: min(90vw, 1200px);
+  width: min(92vw, 1080px);
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 clamp(1.5rem, 3vw, 3rem);
   box-sizing: border-box;
 }
 
@@ -50,20 +65,27 @@ a {
 
 a:hover {
   text-decoration: underline;
+  color: #9f4f23;
 }
 
-h1 { font-size: 2.5rem; }
-h2 { font-size: 2rem; }
-h3 { font-size: 1.5rem; }
-h4, h5, h6 { font-size: 1.25rem; }
+h1 { font-size: 2.4rem; }
+h2 { font-size: 1.9rem; }
+h3 { font-size: 1.45rem; }
+h4, h5, h6 { font-size: 1.2rem; }
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-family-heading);
   font-weight: 600;
-  letter-spacing: 0.01em;
-  line-height: 1.3;
-  margin-top: 2em;
+  letter-spacing: 0.02em;
+  line-height: 1.32;
+  margin-top: 2.2em;
   margin-bottom: 0.5em;
+}
+
+h1 strong,
+h2 strong,
+h3 strong {
+  font-weight: 700;
 }
 
 /* Header */
@@ -71,6 +93,9 @@ header {
   height: var(--header-height);
   display: flex;
   justify-content: center;
+  background: rgba(246, 241, 231, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(133, 117, 96, 0.18);
 }
 
 header nav {
@@ -78,10 +103,22 @@ header nav {
   justify-content: space-between;
   align-items: center;
   height: 100%;
-  width: 60vw;
-  padding: 0 20px;
+  width: min(92vw, 1080px);
+  padding: 0 clamp(1.5rem, 3vw, 2.75rem);
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border-color);
+}
+
+header nav ul a {
+  font-family: var(--font-family-heading);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  font-size: 0.82rem;
+}
+
+header nav ul a:hover {
+  color: var(--accent-color);
 }
 
 .nav-logo {
@@ -107,16 +144,16 @@ header nav ul {
 
 /* Main content */
 main {
-  padding: 40px 0;
+  padding: 48px 0 64px;
 }
 
 /* Footer */
 footer {
   text-align: center;
-  padding: 40px 0;
-  border-top: 1px solid var(--border-color);
+  padding: 48px 0;
   color: var(--text-secondary);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
 }
 
 footer p {
@@ -124,16 +161,22 @@ footer p {
 }
 
 footer a {
-  color: var(--text-secondary);
+  color: var(--accent-color);
 }
 
 /* New Homepage Styles */
 .intro-section {
   display: flex;
   align-items: center;
-  padding: 40px 0;
-  gap: 40px;
+  gap: clamp(2rem, 6vw, 4rem);
   flex-wrap: wrap;
+  padding: clamp(2.5rem, 7vw, 4rem);
+  margin-bottom: 36px;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-color);
+  border-radius: 32px;
+  box-shadow: var(--soft-shadow);
+  backdrop-filter: blur(8px);
 }
 
 .intro-text {
@@ -143,35 +186,50 @@ footer a {
 
 .intro-text h1 {
   margin-top: 0;
-  font-size: 3rem;
+  font-size: clamp(2.4rem, 5vw, 2.9rem);
   font-weight: 700;
+  letter-spacing: 0.03em;
 }
 
 .intro-text .subtitle {
-  font-size: 1.25rem;
+  font-size: clamp(1.05rem, 2.6vw, 1.2rem);
   color: var(--text-secondary);
+  letter-spacing: 0.04em;
 }
 
 .intro-description {
-  margin-top: 1.2rem;
-  font-size: 1.05rem;
+  margin-top: 1.1rem;
+  font-size: 1rem;
   color: var(--text-secondary);
 }
 
 .contact-links {
-  margin-top: 20px;
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
 }
 
 .contact-links a {
-  margin-right: 15px;
   font-weight: 600;
+  letter-spacing: 0.04em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.contact-links a:hover {
+  color: #9f4f23;
+  border-color: rgba(198, 107, 61, 0.4);
 }
 
 .intro-image img {
-  width: 150px;
-  height: 150px;
+  width: clamp(150px, 22vw, 200px);
+  height: clamp(150px, 22vw, 200px);
   border-radius: 50%;
   object-fit: cover;
+  box-shadow: 0 12px 30px rgba(58, 50, 39, 0.16);
+  border: 3px solid rgba(198, 107, 61, 0.35);
 }
 
 .intro-image {
@@ -182,12 +240,25 @@ footer a {
 }
 
 .content-section {
-  padding: 20px 0;
-  border-top: 1px solid var(--border-color);
+  margin-top: 44px;
+  padding: 36px clamp(1.5rem, 3vw, 3rem);
+  background: var(--surface-card);
+  border: 1px solid var(--border-color);
+  border-radius: 26px;
+  box-shadow: var(--soft-shadow);
+  backdrop-filter: blur(6px);
+}
+
+.content-section:first-of-type {
+  margin-top: 20px;
 }
 
 .content-section h2 {
   margin-top: 0;
+  color: var(--text-primary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 1.6rem;
 }
 
 /* Timeline */
@@ -208,7 +279,7 @@ footer a {
   top: 4px;
   bottom: 4px;
   width: var(--timeline-line-width);
-  background: linear-gradient(180deg, rgba(0, 122, 255, 0.45), rgba(0, 122, 255, 0));
+  background: linear-gradient(180deg, rgba(198, 107, 61, 0.5), rgba(198, 107, 61, 0));
 }
 
 .timeline-item {
@@ -230,32 +301,36 @@ footer a {
   width: var(--timeline-marker-diameter);
   height: var(--timeline-marker-diameter);
   border-radius: 50%;
-  background: linear-gradient(135deg, #007aff, #4fb6ff);
-  box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+  background: linear-gradient(135deg, #c66b3d, #f19961);
+  box-shadow: 0 0 0 6px rgba(198, 107, 61, 0.18);
   animation: pulse 6s ease-in-out infinite;
 }
 
 .timeline-date {
   font-weight: 600;
-  color: var(--text-secondary);
+  color: var(--text-muted);
   padding-top: 6px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .timeline-body {
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 14px;
-  padding: 18px 22px;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 252, 0.96);
+  border: 1px solid rgba(133, 117, 96, 0.18);
+  border-radius: 18px;
+  padding: 20px 24px;
+  box-shadow: 0 18px 36px rgba(73, 56, 36, 0.12);
 }
 
 .timeline-body h3 {
   margin-top: 0;
-  font-size: 1.3rem;
+  font-size: 1.28rem;
+  letter-spacing: 0.015em;
 }
 
 .timeline-body p {
   margin-top: 0.6rem;
+  color: var(--text-secondary);
 }
 
 .timeline-body p:first-of-type {
@@ -271,11 +346,11 @@ footer a {
   0%,
   100% {
     transform: scale(1);
-    box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+    box-shadow: 0 0 0 6px rgba(198, 107, 61, 0.18);
   }
   50% {
     transform: scale(1.1);
-    box-shadow: 0 0 0 10px rgba(0, 122, 255, 0.1);
+    box-shadow: 0 0 0 10px rgba(198, 107, 61, 0.12);
   }
 }
 
@@ -293,11 +368,11 @@ footer a {
 }
 
 .skills-card {
-  background: #ffffff;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 18px;
+  background: rgba(255, 255, 252, 0.96);
+  border: 1px solid rgba(133, 117, 96, 0.18);
+  border-radius: 22px;
   padding: 24px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--soft-shadow);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -306,7 +381,7 @@ footer a {
 
 .skills-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 28px 50px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 28px 50px rgba(73, 56, 36, 0.16);
 }
 
 .card-header {
@@ -319,13 +394,13 @@ footer a {
   width: 52px;
   height: 52px;
   border-radius: 16px;
-  background: linear-gradient(135deg, rgba(0, 122, 255, 0.15), rgba(0, 122, 255, 0.35));
+  background: linear-gradient(135deg, rgba(198, 107, 61, 0.18), rgba(241, 153, 97, 0.32));
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 1.6rem;
-  color: #0052a3;
-  box-shadow: inset 0 0 0 1px rgba(0, 122, 255, 0.25);
+  color: #8d4317;
+  box-shadow: inset 0 0 0 1px rgba(198, 107, 61, 0.4);
   animation: float 8s ease-in-out infinite;
 }
 
@@ -342,8 +417,8 @@ footer a {
 
 .skill-badge {
   --badge-surface: #ffffff;
-  --badge-border: rgba(15, 23, 42, 0.12);
-  --badge-text: #0f172a;
+  --badge-border: rgba(90, 70, 48, 0.18);
+  --badge-text: #3a3227;
   display: inline-flex;
   align-items: center;
   gap: 0.65rem;
@@ -351,7 +426,7 @@ footer a {
   border-radius: 999px;
   background: var(--badge-surface);
   border: 1px solid var(--badge-border);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 18px rgba(73, 56, 36, 0.12);
   color: var(--badge-text);
   text-decoration: none;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
@@ -371,7 +446,7 @@ footer a {
 
 .skill-badge:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 14px 30px rgba(73, 56, 36, 0.18);
 }
 
 @keyframes float {
@@ -419,7 +494,9 @@ footer a {
   .intro-section {
     flex-direction: column;
     text-align: center;
+    align-items: center;
     gap: 24px;
+    padding: clamp(2rem, 10vw, 3rem);
   }
 
   .intro-text {
@@ -488,28 +565,11 @@ footer a {
 }
 
 /* Home layout */
-.home-container {
-  width: 100%;
-  max-width: 60vw;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  box-sizing: border-box;
-}
-
-/* Blog styles */
-.home-container {
-  width: 100%;
-  max-width: 60vw;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  box-sizing: border-box;
-}
-
+.home-container,
 .blog-container {
-  width: 100%;
-  max-width: 60vw;
+  width: min(92vw, 1080px);
   margin: 0 auto;
-  padding: 0 1.5rem;
+  padding: 0 clamp(1.5rem, 3vw, 3rem);
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- switch the global font stack to Source Serif 4 and Work Sans with reduced sizing to echo thekev.in’s blog typography
- refresh the color palette, spacing, and card treatments with warm neutral surfaces and accent details for a softer visual hierarchy
- update intro, timeline, and skills modules to share the new styling while preserving the existing content and skill icons

## Testing
- `bundle exec jekyll build` *(fails: Jekyll gem unavailable in the container)*
- `bundle install` *(fails: Gemfile requires Ruby ~> 3.4, container provides 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f592a860833393a8b85b50757014