### PR TITLE
Refine typography and styling for blog homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,18 +1,23 @@
 /* General styles */
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;500;600;700&family=Work+Sans:wght@500;600;700&display=swap');
+
 :root {
-  --text-primary: #333;
-  --text-secondary: #555;
-  --background-primary: #fff;
-  --accent-color: #007aff;
-  --border-color: #e5e5e5;
+  --text-primary: #2f2a24;
+  --text-secondary: #5b5146;
+  --background-primary: #f8f4ec;
+  --background-elevated: #ffffff;
+  --accent-color: #b8622b;
+  --border-color: rgba(91, 81, 70, 0.18);
   --header-height: 80px;
-  --font-family-base: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-family-heading: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-family-base: 'EB Garamond', 'Iowan Old Style', 'Times New Roman', serif;
+  --font-family-heading: 'Work Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 body {
   font-family: var(--font-family-base);
-  line-height: 1.6;
+  font-size: clamp(14px, 0.45vw + 13px, 16px);
+  line-height: 1.7;
+  letter-spacing: 0.01em;
   color: var(--text-primary);
   background-color: var(--background-primary);
   margin: 0;
@@ -29,7 +34,7 @@ body {
 }
 
 .container > header {
-  width: 60vw;
+  width: min(90vw, 960px);
   margin: 0 auto;
   padding: 0 20px;
   box-sizing: border-box;
@@ -37,7 +42,7 @@ body {
 
 .container > main,
 .container > footer {
-  width: min(90vw, 1200px);
+  width: min(90vw, 1100px);
   margin: 0 auto;
   padding: 0 20px;
   box-sizing: border-box;
@@ -46,24 +51,38 @@ body {
 a {
   color: var(--accent-color);
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-a:hover {
+a:hover,
+a:focus {
+  color: #8a4312;
   text-decoration: underline;
 }
 
-h1 { font-size: 2.5rem; }
-h2 { font-size: 2rem; }
-h3 { font-size: 1.5rem; }
-h4, h5, h6 { font-size: 1.25rem; }
+h1 { font-size: clamp(2.2rem, 4vw, 3rem); }
+h2 { font-size: clamp(1.8rem, 3vw, 2.4rem); }
+h3 { font-size: clamp(1.4rem, 2.4vw, 1.8rem); }
+h4, h5, h6 { font-size: clamp(1.15rem, 2vw, 1.35rem); }
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-family-heading);
   font-weight: 600;
-  letter-spacing: 0.01em;
-  line-height: 1.3;
+  letter-spacing: 0.015em;
+  line-height: 1.28;
   margin-top: 2em;
   margin-bottom: 0.5em;
+}
+
+p,
+li {
+  font-size: 1rem;
+  letter-spacing: 0.005em;
+  color: var(--text-primary);
+}
+
+p {
+  max-width: 70ch;
 }
 
 /* Header */
@@ -78,7 +97,7 @@ header nav {
   justify-content: space-between;
   align-items: center;
   height: 100%;
-  width: 60vw;
+  width: min(90vw, 960px);
   padding: 0 20px;
   box-sizing: border-box;
   border-bottom: 1px solid var(--border-color);
@@ -107,13 +126,13 @@ header nav ul {
 
 /* Main content */
 main {
-  padding: 40px 0;
+  padding: 48px 0 60px;
 }
 
 /* Footer */
 footer {
   text-align: center;
-  padding: 40px 0;
+  padding: 48px 0 32px;
   border-top: 1px solid var(--border-color);
   color: var(--text-secondary);
   font-size: 0.9rem;
@@ -131,7 +150,7 @@ footer a {
 .intro-section {
   display: flex;
   align-items: center;
-  padding: 40px 0;
+  padding: 48px 0;
   gap: 40px;
   flex-wrap: wrap;
 }
@@ -143,13 +162,16 @@ footer a {
 
 .intro-text h1 {
   margin-top: 0;
-  font-size: 3rem;
+  font-size: clamp(2.5rem, 5vw, 3.2rem);
   font-weight: 700;
 }
 
 .intro-text .subtitle {
-  font-size: 1.25rem;
+  font-family: var(--font-family-heading);
+  font-size: clamp(1.05rem, 2vw, 1.2rem);
   color: var(--text-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .intro-description {
@@ -165,6 +187,9 @@ footer a {
 .contact-links a {
   margin-right: 15px;
   font-weight: 600;
+  font-family: var(--font-family-heading);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .intro-image img {
@@ -182,7 +207,7 @@ footer a {
 }
 
 .content-section {
-  padding: 20px 0;
+  padding: 32px 0 28px;
   border-top: 1px solid var(--border-color);
 }
 
@@ -208,7 +233,7 @@ footer a {
   top: 4px;
   bottom: 4px;
   width: var(--timeline-line-width);
-  background: linear-gradient(180deg, rgba(0, 122, 255, 0.45), rgba(0, 122, 255, 0));
+  background: linear-gradient(180deg, rgba(184, 98, 43, 0.45), rgba(184, 98, 43, 0));
 }
 
 .timeline-item {
@@ -230,8 +255,8 @@ footer a {
   width: var(--timeline-marker-diameter);
   height: var(--timeline-marker-diameter);
   border-radius: 50%;
-  background: linear-gradient(135deg, #007aff, #4fb6ff);
-  box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+  background: linear-gradient(135deg, #b8622b, #d89249);
+  box-shadow: 0 0 0 6px rgba(184, 98, 43, 0.18);
   animation: pulse 6s ease-in-out infinite;
 }
 
@@ -242,11 +267,11 @@ footer a {
 }
 
 .timeline-body {
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  background: var(--background-elevated);
+  border: 1px solid rgba(91, 81, 70, 0.16);
   border-radius: 14px;
   padding: 18px 22px;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 36px rgba(47, 42, 36, 0.08);
 }
 
 .timeline-body h3 {
@@ -271,11 +296,11 @@ footer a {
   0%,
   100% {
     transform: scale(1);
-    box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+    box-shadow: 0 0 0 6px rgba(184, 98, 43, 0.18);
   }
   50% {
     transform: scale(1.1);
-    box-shadow: 0 0 0 10px rgba(0, 122, 255, 0.1);
+    box-shadow: 0 0 0 10px rgba(184, 98, 43, 0.12);
   }
 }
 
@@ -293,11 +318,11 @@ footer a {
 }
 
 .skills-card {
-  background: #ffffff;
-  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--background-elevated);
+  border: 1px solid rgba(91, 81, 70, 0.16);
   border-radius: 18px;
   padding: 24px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 16px 32px rgba(47, 42, 36, 0.1);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -306,7 +331,7 @@ footer a {
 
 .skills-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 28px 50px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 26px 46px rgba(47, 42, 36, 0.16);
 }
 
 .card-header {
@@ -319,13 +344,13 @@ footer a {
   width: 52px;
   height: 52px;
   border-radius: 16px;
-  background: linear-gradient(135deg, rgba(0, 122, 255, 0.15), rgba(0, 122, 255, 0.35));
+  background: linear-gradient(135deg, rgba(184, 98, 43, 0.18), rgba(231, 166, 90, 0.35));
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 1.6rem;
-  color: #0052a3;
-  box-shadow: inset 0 0 0 1px rgba(0, 122, 255, 0.25);
+  color: #8a4312;
+  box-shadow: inset 0 0 0 1px rgba(184, 98, 43, 0.28);
   animation: float 8s ease-in-out infinite;
 }
 
@@ -351,7 +376,7 @@ footer a {
   border-radius: 999px;
   background: var(--badge-surface);
   border: 1px solid var(--badge-border);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 20px rgba(47, 42, 36, 0.08);
   color: var(--badge-text);
   text-decoration: none;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
@@ -364,14 +389,16 @@ footer a {
 }
 
 .skill-name {
-  font-size: 0.95rem;
+  font-family: var(--font-family-heading);
+  font-size: 0.9rem;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .skill-badge:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 18px 34px rgba(47, 42, 36, 0.14);
 }
 
 @keyframes float {
@@ -490,7 +517,7 @@ footer a {
 /* Home layout */
 .home-container {
   width: 100%;
-  max-width: 60vw;
+  max-width: min(960px, 90vw);
   margin: 0 auto;
   padding: 0 1.5rem;
   box-sizing: border-box;
@@ -499,7 +526,7 @@ footer a {
 /* Blog styles */
 .home-container {
   width: 100%;
-  max-width: 60vw;
+  max-width: min(960px, 90vw);
   margin: 0 auto;
   padding: 0 1.5rem;
   box-sizing: border-box;
@@ -507,7 +534,7 @@ footer a {
 
 .blog-container {
   width: 100%;
-  max-width: 60vw;
+  max-width: min(860px, 90vw);
   margin: 0 auto;
   padding: 0 1.5rem;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- Switch the site to EB Garamond body text and Work Sans headings with adjusted spacing and a smaller base font size for a calmer reading experience.
- Refresh layout widths and color variables to deliver a warmer palette that aligns with the reference blog while keeping section structure and content intact.
- Retune timeline and skills card treatments, preserving existing icons but softening shadows, gradients, and badge typography for a cohesive visual style.

## Testing
- Not run (jekyll requires Ruby ~> 3.4 which is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d8f592a860833393a8b85b50757014