### PR TITLE
Revamp Material-inspired styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,9 +6,6 @@
   <title>{{ page.title }} | {{ site.title }}</title>
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="icon" type="image/svg+xml" href="{{ "/assets/favicon.svg" | relative_url }}">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "/assets/favicon-32.png" | relative_url }}">
   <link rel="icon" type="image/png" sizes="192x192" href="{{ "/assets/favicon-512.png" | relative_url }}">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,20 +1,35 @@
 /* General styles */
 :root {
-  --text-primary: #333;
-  --text-secondary: #555;
-  --background-primary: #fff;
-  --accent-color: #007aff;
-  --border-color: #e5e5e5;
+  --color-primary: #6750a4;
+  --color-primary-container: #eaddff;
+  --color-secondary: #625b71;
+  --color-tertiary: #7d5260;
+  --color-background: #f7f2fa;
+  --color-surface: #ffffff;
+  --color-surface-variant: #ede7f6;
+  --color-outline: rgba(98, 91, 113, 0.2);
+  --text-primary: #1d192b;
+  --text-secondary: #4a4458;
+  --accent-color: var(--color-primary);
+  --border-color: rgba(98, 91, 113, 0.18);
   --header-height: 80px;
-  --font-family-base: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  --font-family-heading: 'Plus Jakarta Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-family-base: 'Helvetica Neue', 'Calibri Light', 'Roboto', sans-serif;
+  --font-family-heading: 'Helvetica Neue', 'Calibri Light', 'Roboto', sans-serif;
+}
+
+html {
+  font-size: 15px;
 }
 
 body {
   font-family: var(--font-family-base);
-  line-height: 1.6;
+  font-size: 1rem;
+  line-height: 1.7;
   color: var(--text-primary);
-  background-color: var(--background-primary);
+  background:
+    radial-gradient(120% 140% at 0% 0%, rgba(103, 80, 164, 0.08) 0%, rgba(247, 242, 250, 0) 60%),
+    radial-gradient(140% 120% at 100% 0%, rgba(3, 218, 197, 0.08) 0%, rgba(247, 242, 250, 0) 65%),
+    var(--color-background);
   margin: 0;
   padding: 0;
   -webkit-font-smoothing: antialiased;
@@ -29,33 +44,36 @@ body {
 }
 
 .container > header {
-  width: 60vw;
+  width: 100%;
+  max-width: min(92vw, 1080px);
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 28px 20px 0;
   box-sizing: border-box;
 }
 
 .container > main,
 .container > footer {
-  width: min(90vw, 1200px);
+  width: 100%;
+  max-width: min(92vw, 1080px);
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 24px;
   box-sizing: border-box;
 }
 
 a {
   color: var(--accent-color);
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
 a:hover {
-  text-decoration: underline;
+  color: var(--color-tertiary);
 }
 
-h1 { font-size: 2.5rem; }
-h2 { font-size: 2rem; }
-h3 { font-size: 1.5rem; }
-h4, h5, h6 { font-size: 1.25rem; }
+h1 { font-size: 2.35rem; }
+h2 { font-size: 1.85rem; }
+h3 { font-size: 1.45rem; }
+h4, h5, h6 { font-size: 1.2rem; }
 
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-family-heading);
@@ -68,9 +86,11 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Header */
 header {
-  height: var(--header-height);
+  min-height: var(--header-height);
   display: flex;
   justify-content: center;
+  align-items: center;
+  padding-bottom: 18px;
 }
 
 header nav {
@@ -78,10 +98,15 @@ header nav {
   justify-content: space-between;
   align-items: center;
   height: 100%;
-  width: 60vw;
-  padding: 0 20px;
+  width: 100%;
+  max-width: min(92vw, 1080px);
+  padding: 0 30px;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border-color);
+  border-radius: 24px;
+  border: 1px solid var(--color-outline);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 22px 48px rgba(29, 25, 43, 0.16);
+  backdrop-filter: blur(18px);
 }
 
 .nav-logo {
@@ -89,8 +114,11 @@ header nav {
   align-items: center;
   justify-content: center;
   width: 48px;
-  height: 100%;
-  color: var(--text-primary);
+  height: 48px;
+  border-radius: 16px;
+  border: 1px solid rgba(103, 80, 164, 0.24);
+  background: linear-gradient(135deg, rgba(103, 80, 164, 0.18), rgba(3, 218, 197, 0.12));
+  color: var(--color-primary);
 }
 
 .nav-logo:hover {
@@ -102,21 +130,43 @@ header nav ul {
   margin: 0;
   padding: 0;
   display: flex;
-  gap: 20px;
+  gap: 18px;
+}
+
+header nav ul li a {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+header nav ul li a:hover {
+  color: var(--color-primary);
+  background: var(--color-primary-container);
+  box-shadow: 0 10px 24px rgba(103, 80, 164, 0.2);
 }
 
 /* Main content */
 main {
-  padding: 40px 0;
+  padding: 56px 0;
 }
 
 /* Footer */
 footer {
+  position: relative;
   text-align: center;
-  padding: 40px 0;
-  border-top: 1px solid var(--border-color);
+  margin-top: 72px;
+  padding: 40px 0 56px;
+  border-top: none;
   color: var(--text-secondary);
   font-size: 0.9rem;
+  background: var(--color-surface);
+  border-radius: 32px 32px 0 0;
+  box-shadow: 0 -18px 48px rgba(29, 25, 43, 0.12);
 }
 
 footer p {
@@ -124,15 +174,57 @@ footer p {
 }
 
 footer a {
-  color: var(--text-secondary);
+  color: var(--color-primary);
 }
 
 /* New Homepage Styles */
+
+.home-container {
+  position: relative;
+  width: 100%;
+  max-width: min(92vw, 1080px);
+  margin: 0 auto 72px;
+  padding: 48px clamp(24px, 6vw, 56px);
+  box-sizing: border-box;
+  background: var(--color-surface);
+  border-radius: 36px;
+  border: 1px solid var(--color-outline);
+  box-shadow: 0 32px 64px rgba(29, 25, 43, 0.18);
+  overflow: hidden;
+}
+
+.home-container::before,
+.home-container::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(0px);
+  opacity: 0.65;
+}
+
+.home-container::before {
+  width: 280px;
+  height: 280px;
+  top: -140px;
+  right: -120px;
+  background: radial-gradient(circle, rgba(103, 80, 164, 0.18) 0%, rgba(103, 80, 164, 0) 70%);
+}
+
+.home-container::after {
+  width: 220px;
+  height: 220px;
+  bottom: -120px;
+  left: -80px;
+  background: radial-gradient(circle, rgba(3, 218, 197, 0.18) 0%, rgba(3, 218, 197, 0) 70%);
+}
+
 .intro-section {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
-  padding: 40px 0;
-  gap: 40px;
+  padding: 12px 0 32px;
+  gap: clamp(24px, 5vw, 48px);
   flex-wrap: wrap;
 }
 
@@ -143,56 +235,110 @@ footer a {
 
 .intro-text h1 {
   margin-top: 0;
-  font-size: 3rem;
+  font-size: 2.6rem;
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .intro-text .subtitle {
-  font-size: 1.25rem;
+  font-size: 1.15rem;
   color: var(--text-secondary);
 }
 
 .intro-description {
-  margin-top: 1.2rem;
-  font-size: 1.05rem;
+  margin-top: 1.1rem;
+  font-size: 1.02rem;
   color: var(--text-secondary);
 }
 
 .contact-links {
-  margin-top: 20px;
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .contact-links a {
-  margin-right: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 24px;
+  border-radius: 999px;
   font-weight: 600;
+  color: #ffffff;
+  background: var(--color-primary);
+  box-shadow: 0 18px 36px rgba(103, 80, 164, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.contact-links a:nth-child(2) {
+  background: var(--color-secondary);
+  box-shadow: 0 16px 32px rgba(98, 91, 113, 0.28);
+}
+
+.contact-links a:nth-child(3) {
+  background: var(--color-tertiary);
+  box-shadow: 0 16px 30px rgba(125, 82, 96, 0.3);
+}
+
+.contact-links a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 48px rgba(29, 25, 43, 0.28);
+  color: #ffffff;
 }
 
 .intro-image img {
-  width: 150px;
-  height: 150px;
-  border-radius: 50%;
+  width: 164px;
+  height: 164px;
+  border-radius: 38px;
   object-fit: cover;
+  border: 4px solid var(--color-primary-container);
+  box-shadow: 0 20px 36px rgba(103, 80, 164, 0.18);
+  background: var(--color-surface);
 }
 
 .intro-image {
   flex: 0 0 auto;
   display: flex;
   justify-content: center;
-  min-width: 150px;
+  min-width: 164px;
 }
 
 .content-section {
-  padding: 20px 0;
-  border-top: 1px solid var(--border-color);
+  position: relative;
+  margin: 52px 0;
+  padding: 32px clamp(20px, 5vw, 42px);
+  border-radius: 28px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: 0 30px 60px rgba(29, 25, 43, 0.14);
+  overflow: hidden;
+}
+
+.content-section::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  background: linear-gradient(90deg, rgba(103, 80, 164, 0.8), rgba(3, 218, 197, 0.6));
 }
 
 .content-section h2 {
   margin-top: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.content-section.timeline {
+  overflow: visible;
 }
 
 /* Timeline */
 .timeline-track {
   position: relative;
+  z-index: 1;
   margin-top: 30px;
   --timeline-padding: 44px;
   --timeline-line-left: 14px;
@@ -208,14 +354,14 @@ footer a {
   top: 4px;
   bottom: 4px;
   width: var(--timeline-line-width);
-  background: linear-gradient(180deg, rgba(0, 122, 255, 0.45), rgba(0, 122, 255, 0));
+  background: linear-gradient(180deg, rgba(103, 80, 164, 0.55), rgba(103, 80, 164, 0));
 }
 
 .timeline-item {
   position: relative;
   display: grid;
   grid-template-columns: 140px 1fr;
-  gap: 28px;
+  gap: 32px;
   margin-bottom: 48px;
 }
 
@@ -230,8 +376,9 @@ footer a {
   width: var(--timeline-marker-diameter);
   height: var(--timeline-marker-diameter);
   border-radius: 50%;
-  background: linear-gradient(135deg, #007aff, #4fb6ff);
-  box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+  background: linear-gradient(135deg, #6750a4, #7f67be);
+  box-shadow: 0 0 0 6px rgba(103, 80, 164, 0.18);
+  border: 2px solid var(--color-primary-container);
   animation: pulse 6s ease-in-out infinite;
 }
 
@@ -242,11 +389,28 @@ footer a {
 }
 
 .timeline-body {
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 14px;
-  padding: 18px 22px;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  position: relative;
+  background: var(--color-surface-variant);
+  border: 1px solid rgba(103, 80, 164, 0.2);
+  border-radius: 22px;
+  padding: 20px 24px 20px 32px;
+  box-shadow: 0 18px 36px rgba(103, 80, 164, 0.16);
+}
+
+.timeline-body::before {
+  content: "";
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  bottom: 18px;
+  width: 4px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(103, 80, 164, 0.85), rgba(3, 218, 197, 0.7));
+}
+
+.timeline-body > * {
+  position: relative;
+  z-index: 1;
 }
 
 .timeline-body h3 {
@@ -271,11 +435,11 @@ footer a {
   0%,
   100% {
     transform: scale(1);
-    box-shadow: 0 0 0 6px rgba(0, 122, 255, 0.15);
+    box-shadow: 0 0 0 6px rgba(103, 80, 164, 0.18);
   }
   50% {
     transform: scale(1.1);
-    box-shadow: 0 0 0 10px rgba(0, 122, 255, 0.1);
+    box-shadow: 0 0 0 10px rgba(103, 80, 164, 0.12);
   }
 }
 
@@ -293,11 +457,11 @@ footer a {
 }
 
 .skills-card {
-  background: #ffffff;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 18px;
-  padding: 24px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  background: linear-gradient(165deg, rgba(237, 231, 246, 0.65), rgba(255, 255, 255, 0.95));
+  border: 1px solid rgba(103, 80, 164, 0.22);
+  border-radius: 24px;
+  padding: 28px;
+  box-shadow: 0 26px 52px rgba(29, 25, 43, 0.18);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -306,7 +470,7 @@ footer a {
 
 .skills-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 28px 50px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 32px 64px rgba(29, 25, 43, 0.22);
 }
 
 .card-header {
@@ -316,16 +480,16 @@ footer a {
 }
 
 .card-icon {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(0, 122, 255, 0.15), rgba(0, 122, 255, 0.35));
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(103, 80, 164, 0.22), rgba(103, 80, 164, 0.45));
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.6rem;
-  color: #0052a3;
-  box-shadow: inset 0 0 0 1px rgba(0, 122, 255, 0.25);
+  font-size: 1.65rem;
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.22);
   animation: float 8s ease-in-out infinite;
 }
 
@@ -342,8 +506,8 @@ footer a {
 
 .skill-badge {
   --badge-surface: #ffffff;
-  --badge-border: rgba(15, 23, 42, 0.12);
-  --badge-text: #0f172a;
+  --badge-border: rgba(103, 80, 164, 0.22);
+  --badge-text: #1d192b;
   display: inline-flex;
   align-items: center;
   gap: 0.65rem;
@@ -351,7 +515,7 @@ footer a {
   border-radius: 999px;
   background: var(--badge-surface);
   border: 1px solid var(--badge-border);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 24px rgba(29, 25, 43, 0.14);
   color: var(--badge-text);
   text-decoration: none;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
@@ -371,7 +535,8 @@ footer a {
 
 .skill-badge:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.16);
+  box-shadow: 0 20px 40px rgba(29, 25, 43, 0.2);
+  color: var(--badge-text);
 }
 
 @keyframes float {
@@ -487,30 +652,18 @@ footer a {
   margin-bottom: 15px;
 }
 
-/* Home layout */
-.home-container {
-  width: 100%;
-  max-width: 60vw;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  box-sizing: border-box;
-}
-
 /* Blog styles */
-.home-container {
-  width: 100%;
-  max-width: 60vw;
-  margin: 0 auto;
-  padding: 0 1.5rem;
-  box-sizing: border-box;
-}
-
 .blog-container {
+  position: relative;
   width: 100%;
-  max-width: 60vw;
-  margin: 0 auto;
-  padding: 0 1.5rem;
+  max-width: min(92vw, 1080px);
+  margin: 0 auto 72px;
+  padding: 48px clamp(24px, 6vw, 56px);
   box-sizing: border-box;
+  background: var(--color-surface);
+  border-radius: 32px;
+  border: 1px solid var(--color-outline);
+  box-shadow: 0 28px 56px rgba(29, 25, 43, 0.16);
 }
 
 .blog-list {
@@ -519,7 +672,14 @@ footer a {
 }
 
 .blog-list-item {
+  position: relative;
   margin-bottom: 40px;
+  padding: 28px clamp(20px, 5vw, 36px);
+  border-radius: 26px;
+  border: 1px solid var(--color-outline);
+  background: linear-gradient(175deg, rgba(237, 231, 246, 0.4), rgba(255, 255, 255, 0.95));
+  box-shadow: 0 22px 44px rgba(29, 25, 43, 0.16);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .blog-list-item h2 {
@@ -531,6 +691,31 @@ footer a {
   color: var(--text-primary);
 }
 
+.blog-list-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 26px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, rgba(103, 80, 164, 0.35), rgba(3, 218, 197, 0.35)) border-box;
+  mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.blog-list-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 28px 56px rgba(29, 25, 43, 0.2);
+}
+
+.blog-list-item:hover::before {
+  opacity: 1;
+}
+
 .blog-list-item .post-meta {
   font-size: 0.9rem;
   color: var(--text-secondary);
@@ -539,7 +724,13 @@ footer a {
 
 /* Blog Post */
 .post-header {
+  position: relative;
   margin-bottom: 40px;
+  padding: 32px clamp(20px, 5vw, 40px);
+  border-radius: 28px;
+  background: linear-gradient(170deg, rgba(237, 231, 246, 0.55), rgba(255, 255, 255, 0.95));
+  border: 1px solid var(--color-outline);
+  box-shadow: 0 24px 52px rgba(29, 25, 43, 0.16);
 }
 
 .post-header h1 {
@@ -551,6 +742,11 @@ footer a {
   font-size: 1rem;
   line-height: 1.7;
   overflow-wrap: anywhere;
+  padding: 32px clamp(20px, 5vw, 44px);
+  border-radius: 32px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  box-shadow: 0 26px 56px rgba(29, 25, 43, 0.16);
 }
 
 .post-content img,
@@ -572,8 +768,10 @@ footer a {
   max-width: 100%;
   overflow-x: auto;
   padding: 1.2rem;
-  border-radius: 8px;
-  background: #f5f7fa;
+  border-radius: 14px;
+  background: var(--color-surface-variant);
+  border: 1px solid rgba(103, 80, 164, 0.22);
+  box-shadow: 0 14px 28px rgba(29, 25, 43, 0.12);
   box-sizing: border-box;
 }
 
@@ -606,21 +804,28 @@ footer a {
 .post-content table td,
 .post-content table th {
   padding: 0.75rem 1rem;
-  border: 1px solid #e0e0e0;
+  border: 1px solid rgba(98, 91, 113, 0.2);
 }
 
 /* Responsive Design */
 @media (max-width: 768px) {
+  header nav {
+    padding: 0 20px;
+    border-radius: 20px;
+  }
+
   .home-container,
   .blog-container {
     width: 100%;
     max-width: 100%;
-    padding: 0 1.25rem;
+    margin: 0 auto 56px;
+    padding: 32px 20px;
+    border-radius: 28px;
   }
 }
 .container > main {
-  padding-top: 40px;
-  padding-bottom: 40px;
+  padding-top: 56px;
+  padding-bottom: 56px;
 }
 
 body.post-page .container > main,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -198,7 +198,6 @@ footer a {
   content: "";
   position: absolute;
   border-radius: 999px;
-  filter: blur(0px);
   opacity: 0.65;
 }
 
@@ -266,17 +265,20 @@ footer a {
   border-radius: 999px;
   font-weight: 600;
   color: #ffffff;
-  background: var(--color-primary);
-  box-shadow: 0 18px 36px rgba(103, 80, 164, 0.28);
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
-.contact-links a:nth-child(2) {
+.contact-links a.github {
+  background: var(--color-primary);
+  box-shadow: 0 18px 36px rgba(103, 80, 164, 0.28);
+}
+
+.contact-links a.linkedin {
   background: var(--color-secondary);
   box-shadow: 0 16px 32px rgba(98, 91, 113, 0.28);
 }
 
-.contact-links a:nth-child(3) {
+.contact-links a.email {
   background: var(--color-tertiary);
   box-shadow: 0 16px 30px rgba(125, 82, 96, 0.3);
 }
@@ -284,7 +286,6 @@ footer a {
 .contact-links a:hover {
   transform: translateY(-2px);
   box-shadow: 0 24px 48px rgba(29, 25, 43, 0.28);
-  color: #ffffff;
 }
 
 .intro-image img {
@@ -536,7 +537,6 @@ footer a {
 .skill-badge:hover {
   transform: translateY(-2px);
   box-shadow: 0 20px 40px rgba(29, 25, 43, 0.2);
-  color: var(--badge-text);
 }
 
 @keyframes float {

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@ title: "Home"
         domain expertise, orchestrating reliable deployments, and crafting the tooling that keeps teams shipping.
       </p> -->
       <div class="contact-links">
-        <a href="https://github.com/zaffnet" target="_blank">GitHub</a>
-        <a href="https://www.linkedin.com/in/zaffnet" target="_blank">LinkedIn</a>
-        <a href="mailto:zafarullah.mahmood@gmail.com">Email</a>
+        <a class="github" href="https://github.com/zaffnet" target="_blank">GitHub</a>
+        <a class="linkedin" href="https://www.linkedin.com/in/zaffnet" target="_blank">LinkedIn</a>
+        <a class="email" href="mailto:zafarullah.mahmood@gmail.com">Email</a>
       </div>
     </div>
     <div class="intro-image">


### PR DESCRIPTION
## Summary
- adopt a Helvetica-based typography stack and Material Design color palette across the site
- refresh the hero, timeline, skills, blog, and post sections with elevated Material-style surfaces and interactions

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 --livereload --livereload-port 35729 *(fails: jekyll gem unavailable because the environment lacks the required Ruby version)*
- bundle install *(fails: Gemfile requires Ruby ~> 3.4 but the container provides 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68d9157b83c08333a54138cef7f45512